### PR TITLE
 Fixed the AttributeError & Temporary fix to target value

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -5,6 +5,7 @@ import argparse
 import time
 import numpy as np
 from PIL.Image import Image
+from PIL import Image
 import torch.utils.data as data
 from models.MyNetworks import ESFNet
 import torchvision.transforms as transforms

--- a/predict.py
+++ b/predict.py
@@ -77,7 +77,7 @@ class Predictor(object):
 
         with torch.no_grad():
             tic = time.time()
-            for steps, (data, target, filenames) in enumerate(self.dataloader_predict, start=1):
+            for steps, (data, filenames) in enumerate(self.dataloader_predict, start=1):
                 # data
                 data = data.to(self.device, non_blocking = True)
                 data_time.update(time.time() - tic)


### PR DESCRIPTION
The AttributeError error which is caused because `import *` created a confusion between `PIL.Image` and `PIL.Image.Image`
```
Traceback (most recent call last):
  File "predict.py", line 150, in <module>
    predictor.predict()
  File "predict.py", line 80, in predict
    for steps, (data, target, filenames) in enumerate(self.dataloader_predict, start=1):
ValueError: not enough values to unpack (expected 3, got 2)
```

The target error, it is missing:
note that this is a temporary fix.
```
Traceback (most recent call last):
  File "predict.py", line 150, in <module>
    predictor.predict()
  File "predict.py", line 80, in predict
    for steps, (data, target, filenames) in enumerate(self.dataloader_predict, start=1):
ValueError: not enough values to unpack (expected 3, got 2)
```